### PR TITLE
feat: 내역이 없을 경우 알려주기

### DIFF
--- a/front-end/package.json
+++ b/front-end/package.json
@@ -11,6 +11,7 @@
     "react": "^18.0.0",
     "react-bootstrap": "^2.2.3",
     "react-dom": "^18.0.0",
+    "react-icons": "^4.3.1",
     "react-scripts": "5.0.0",
     "web-vitals": "^2.1.4"
   },

--- a/front-end/src/App.js
+++ b/front-end/src/App.js
@@ -2,6 +2,7 @@ import './App.css';
 import {Dropdown, DropdownButton} from 'react-bootstrap';
 import {useEffect, useReducer, useState} from 'react';
 import PaymentListView from './components/PaymentListView';
+import ProcessingSpinner from './common/ProcessingSpinner';
 import SummaryBySign from './components/SummaryBySign';
 import * as Api from './common/Api';
 
@@ -19,9 +20,9 @@ function App() {
         {i + 1}월
       </Dropdown.Item>);
 
-  const [state, dispatch] = useReducer((_, action) => ({
+  const [state, dispatch] = useReducer((_state, action) => ({
     processing: action.processing,
-    payments: action.data ?? []
+    payments: action.processing ? _state.payments : action.data ?? []
   }), { processing: false, payments: [] });
 
   useEffect(() => {
@@ -51,13 +52,13 @@ function App() {
         <article className="abs-monthly-summary">
           <SummaryBySign
             payments={state.payments}
-            processing={state.processing}
             mt="1"
           />
+          <ProcessingSpinner processing={state.processing} />
         </article>
       </header>
       <main className="app-main">
-        <PaymentListView payments={state.payments} />
+        {! state.processing && <PaymentListView payments={state.payments} />}
       </main>
     </div>
   );

--- a/front-end/src/components/PaymentListView.css
+++ b/front-end/src/components/PaymentListView.css
@@ -28,5 +28,8 @@
 }
 
 .abs-payment-list-view p {
-  text-align: center;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: .4em;
 }

--- a/front-end/src/components/PaymentListView.css
+++ b/front-end/src/components/PaymentListView.css
@@ -26,3 +26,7 @@
   display: flex;
   justify-content: space-between;
 }
+
+.abs-payment-list-view p {
+  text-align: center;
+}

--- a/front-end/src/components/PaymentListView.js
+++ b/front-end/src/components/PaymentListView.js
@@ -15,6 +15,7 @@ function PaymentListView(props) {
 
   return (
     <article className="abs-payment-list-view">
+      {paymentsByDate.length === 0 && <p>내역이 없어요.</p>}
       {paymentsByDate.map(payments =>
         <section
           key={payments.key}

--- a/front-end/src/components/PaymentListView.js
+++ b/front-end/src/components/PaymentListView.js
@@ -1,5 +1,6 @@
 import './PaymentListView.css';
 import SummaryBySign from './SummaryBySign';
+import { BsExclamationCircle } from "react-icons/bs";
 
 function PaymentListView(props) {
   let currentDate;
@@ -15,7 +16,8 @@ function PaymentListView(props) {
 
   return (
     <article className="abs-payment-list-view">
-      {paymentsByDate.length === 0 && <p>내역이 없어요.</p>}
+      {paymentsByDate.length === 0 &&
+        <p><BsExclamationCircle />내역이 없어요.</p>}
       {paymentsByDate.map(payments =>
         <section
           key={payments.key}

--- a/front-end/src/components/SummaryBySign.js
+++ b/front-end/src/components/SummaryBySign.js
@@ -1,5 +1,3 @@
-import ProcessingSpinner from '../common/ProcessingSpinner';
-
 /**
  * @typedef {Object} Payment
  * @property {string} category
@@ -23,7 +21,6 @@ function SummaryBySign(props) {
     <>
       <h6><b style={{'color': '#02d505'}}>수입: </b>{income.toLocaleString()}원</h6>
       <h6><b style={{'color': '#fd2926'}}>지출: </b>{outgoing.toLocaleString()}원</h6>
-      <ProcessingSpinner processing={props.processing} />
     </>
   );
 }

--- a/front-end/yarn.lock
+++ b/front-end/yarn.lock
@@ -7072,6 +7072,11 @@ react-error-overlay@^6.0.11:
   resolved "https://registry.yarnpkg.com/react-error-overlay/-/react-error-overlay-6.0.11.tgz#92835de5841c5cf08ba00ddd2d677b6d17ff9adb"
   integrity sha512-/6UZ2qgEyH2aqzYZgQPxEnz33NJ2gNsnHA2o5+o4wW9bLM/JYQitNP9xPhsXwC08hMMovfGe/8retsdDsczPRg==
 
+react-icons@^4.3.1:
+  version "4.3.1"
+  resolved "https://registry.yarnpkg.com/react-icons/-/react-icons-4.3.1.tgz#2fa92aebbbc71f43d2db2ed1aed07361124e91ca"
+  integrity sha512-cB10MXLTs3gVuXimblAdI71jrJx8njrJZmNMEMC+sQu5B/BIOmlsAjskdqpn81y8UBVEGuHODd7/ci5DvoSzTQ==
+
 react-is@^16.13.1, react-is@^16.3.2:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"


### PR DESCRIPTION
### What is this PR? 🔍

- #37 
- https://react-icons.github.io/react-icons/

### Changes 📝
- 내역이 없으면 아이콘과 메시지를 보여준다.
- Spinner를 하위 컴포넌트에서 빼고 실질적으로 요청을 날리는 컴포넌트에서 돌리게 수정했다.
- 요청을 보내고 응답을 받기 전까지 가지고 있던 거래 내역을 버리지 않도록 수정
- `processing: true` 상태면 하위 컴포넌트를 보여주지 않도록 숨김
