### PR TITLE
fix: Slack API 요청할 때와 가져온 채팅을 필터링할 때 타임존 다르게 설정

### DIFF
--- a/back-end/pkg/slack/history.go
+++ b/back-end/pkg/slack/history.go
@@ -46,7 +46,6 @@ func (mp *MessageParameters) StartAsTime(location string) time.Time {
 	if len(location) > 0 {
 		loc, _ := time.LoadLocation(location)
 		startTime, err = time.ParseInLocation("2006-01", mp.Start, loc)
-
 	} else {
 		startTime, err = time.Parse("2006-01", mp.Start)
 	}

--- a/back-end/pkg/slack/slack_test.go
+++ b/back-end/pkg/slack/slack_test.go
@@ -23,7 +23,7 @@ func init() {
 
 func TestHistory(t *testing.T) {
 	parameters := MessageParameters{
-		Start: "2022-04",
+		Start: "2022-05",
 		End:   "2022-05",
 	}
 


### PR DESCRIPTION
### What is this PR? 🔍

- #40 

### Changes 📝
- 날짜 파라미터를 사용할 때 타임존을 설정할 수 있도록 수정
