### PR TITLE
64 절대 경로로 import 할 수 있게 수정하기

### DIFF
--- a/front-end/config-overrides.js
+++ b/front-end/config-overrides.js
@@ -1,0 +1,8 @@
+const path = require('path');
+
+module.exports = function override(config) {
+  config.resolve.alias = {
+    '@': path.resolve(__dirname, 'src/')
+  }
+  return config;
+}

--- a/front-end/config-overrides.js
+++ b/front-end/config-overrides.js
@@ -1,8 +1,6 @@
-const path = require('path');
+const webpackConfig = require('./webpack.config.js');
 
 module.exports = function override(config) {
-  config.resolve.alias = {
-    '@': path.resolve(__dirname, 'src/')
-  }
+  config.resolve.alias = webpackConfig.resolve.alias;
   return config;
 }

--- a/front-end/package.json
+++ b/front-end/package.json
@@ -9,6 +9,7 @@
     "axios": "^0.26.1",
     "bootstrap": "^5.1.3",
     "react": "^18.0.0",
+    "react-app-rewired": "^2.2.1",
     "react-bootstrap": "^2.2.3",
     "react-dom": "^18.0.0",
     "react-icons": "^4.3.1",
@@ -16,9 +17,9 @@
     "web-vitals": "^2.1.4"
   },
   "scripts": {
-    "start": "react-scripts start",
-    "build": "react-scripts build",
-    "test": "react-scripts test",
+    "start": "react-app-rewired start",
+    "build": "react-app-rewired build",
+    "test": "react-app-rewired test",
     "eject": "react-scripts eject"
   },
   "eslintConfig": {

--- a/front-end/src/App.js
+++ b/front-end/src/App.js
@@ -1,11 +1,11 @@
-import './App.css';
+import '@/App.css';
 import {Dropdown, DropdownButton} from 'react-bootstrap';
 import {useState} from 'react';
-import PaymentListView from './components/PaymentListView';
-import ProcessingSpinner from './common/ProcessingSpinner';
-import SummaryBySign from './components/SummaryBySign';
-import useRequest from './common/useRequest';
-import ErrorLogger from './components/ErrorLogger';
+import PaymentListView from '@/components/PaymentListView';
+import ProcessingSpinner from '@/common/ProcessingSpinner';
+import SummaryBySign from '@/components/SummaryBySign';
+import useRequest from '@/common/useRequest';
+import ErrorLogger from '@/components/ErrorLogger';
 
 function App() {
   const [currentMonth, setCurrentMonth] = useState(new Date().getMonth());

--- a/front-end/src/App.test.js
+++ b/front-end/src/App.test.js
@@ -1,5 +1,5 @@
 import { render, screen } from '@testing-library/react';
-import App from './App';
+import App from '@/App';
 
 test('renders learn react link', () => {
   render(<App />);

--- a/front-end/src/common/ProcessingSpinner.js
+++ b/front-end/src/common/ProcessingSpinner.js
@@ -1,4 +1,4 @@
-import './ProcessingSpinner.css';
+import '@/common/ProcessingSpinner.css';
 import {Spinner} from 'react-bootstrap';
 
 function ProcessingSpinner(props) {

--- a/front-end/src/common/useRequest.js
+++ b/front-end/src/common/useRequest.js
@@ -1,6 +1,6 @@
 import axios from 'axios';
 import { useContext, useEffect, useReducer, useState } from 'react';
-import ErrorContext from './ErrorContext';
+import ErrorContext from '@/common/ErrorContext';
 
 /** @typedef {any} ResponseDataType */
 /**

--- a/front-end/src/components/ErrorLogger.js
+++ b/front-end/src/components/ErrorLogger.js
@@ -1,5 +1,5 @@
 import { useContext, useState } from 'react';
-import { ErrorContext } from '../common/ErrorContext';
+import { ErrorContext } from '@/common/ErrorContext';
 import { Toast } from 'react-bootstrap';
 
 function ErrorToast(props) {

--- a/front-end/src/components/PaymentListView.js
+++ b/front-end/src/components/PaymentListView.js
@@ -1,5 +1,5 @@
-import './PaymentListView.css';
-import SummaryBySign from './SummaryBySign';
+import '@/components/PaymentListView.css';
+import SummaryBySign from '@/components/SummaryBySign';
 import { BsExclamationCircle } from "react-icons/bs";
 
 function PaymentListView(props) {

--- a/front-end/src/index.js
+++ b/front-end/src/index.js
@@ -1,8 +1,8 @@
 import React from 'react';
-import './index.css';
+import '@/index.css';
 import 'bootstrap/dist/css/bootstrap.min.css';
-import App from './App';
-import reportWebVitals from './reportWebVitals';
+import App from '@/App';
+import reportWebVitals from '@/reportWebVitals';
 import { createRoot } from 'react-dom/client';
 
 const container = document.getElementById('root');

--- a/front-end/webpack.config.js
+++ b/front-end/webpack.config.js
@@ -1,0 +1,10 @@
+const path = require('path');
+
+// react-scripts의 의존성에 포함된 webpack config를 config-overrides.js에서 덮어쓴다.
+module.exports = {
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, 'src/'),
+    },
+  }
+}

--- a/front-end/yarn.lock
+++ b/front-end/yarn.lock
@@ -7012,6 +7012,13 @@ react-app-polyfill@^3.0.0:
     regenerator-runtime "^0.13.9"
     whatwg-fetch "^3.6.2"
 
+react-app-rewired@^2.2.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/react-app-rewired/-/react-app-rewired-2.2.1.tgz#84901ee1e3f26add0377ebec0b41bcdfce9fc211"
+  integrity sha512-uFQWTErXeLDrMzOJHKp0h8P1z0LV9HzPGsJ6adOtGlA/B9WfT6Shh4j2tLTTGlXOfiVx6w6iWpp7SOC5pvk+gA==
+  dependencies:
+    semver "^5.6.0"
+
 react-bootstrap@^2.2.3:
   version "2.2.3"
   resolved "https://registry.yarnpkg.com/react-bootstrap/-/react-bootstrap-2.2.3.tgz#1c563018c8b856071334dd5a35f25507185136e2"
@@ -7507,6 +7514,11 @@ semver@7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.0.0.tgz#5f3ca35761e47e05b206c6daff2cf814f0316b8e"
   integrity sha512-+GB6zVA9LWh6zovYQLALHwv5rb2PHGlJi3lfiqIHxR0uuwCgefcOJc59v9fv1w8GbStwxuuqqAjI9NMAOOgq1A==
+
+semver@^5.6.0:
+  version "5.7.1"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.1.tgz#a954f931aeba508d307bbf069eff0c01c96116f7"
+  integrity sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==
 
 semver@^6.0.0, semver@^6.1.1, semver@^6.1.2, semver@^6.3.0:
   version "6.3.0"


### PR DESCRIPTION
### What is this PR? 🔍

- #64 
- [webpack: Resolve](https://webpack.js.org/configuration/resolve/)
- [stack overflow: How to update webpack config for a react project created using create-react-app?](https://stackoverflow.com/questions/63280109/how-to-update-webpack-config-for-a-react-project-created-using-create-react-app)
- [react-app-rewired](https://www.npmjs.com/package/react-app-rewired)

### Changes 📝
* react-app-rewired 라이브러리 설치
  * 이미 react로 인해 프로젝트 안에서 webpack을 사용하고 있기 때문에 webpack을 추가로 설치하고 싶지 않았다. 
  * 복잡해보여서 eject를 하고 싶지 않았다.
* `config-overrides.js`, `webpack.config.js` 파일 생성
  * Webstorm에서 alias path를 인식할 수 있도록 `webpack.config.js`를 Manually 지정해주고 이 파일을 `config-overrides.js`에서 참조하도록 한다.